### PR TITLE
Update config.fish

### DIFF
--- a/dotfile/fish/config.fish
+++ b/dotfile/fish/config.fish
@@ -3,10 +3,11 @@ if status is-interactive
 
 neofetch
 
-alias grep='grep --color=auto'
-alias ls='eza -Bh --icons'
-alias ll='eza -Bhl --icons'
-alias la='eza -lA --icons'
+alias grep='rg --color=auto'
+alias ls='eza --icons'
+alias ll='eza -hl --icons'
+alias la='eza -A --icons'
+alias lla='eza -lAh --icons'
 alias cat='bat --theme=base16 --style=plain --paging=never'
 alias update-arch='yay -Syyu'
 alias clean-arch='yay -Sc && yay -Yc'


### PR DESCRIPTION
Ajout de ripgrep en remplacement de grep
suppression de l'option "B" dans les variantes d'"ls" car non nécessaire. Dite bonjours à "lla" qui remplace "la" qui lister les fichiers plutot que de juste montrer les fichiers cachées. "la" ne sert donc plus qu'à ajouter les fichiers cachés dans la liste des fichiers montrés